### PR TITLE
Fix link for third article preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,17 +120,17 @@
 								<p>Explora los conceptos básicos y avanzados que hacen posible la inteligencia artificial, desde el aprendizaje automático hasta el procesamiento de datos.</p>
 							</div>
 						</div>
-						<div>
-							<div class="image fit">
-								<p href="articulo-ai-potenciar-negocio.html" class="gallery-link">
-									<img src="images/pic04.jpg" alt="" width="600" height="300">
-									<header class="align-center gallery-title">
-										<h3>Cómo potenciar tu negocio con AI.</h3>
-									</header>
-								</p>
-								<p>Conoce estrategias prácticas para implementar soluciones de AI en tu empresa y llevar tus resultados al siguiente nivel.</p>
-							</div>
-						</div>
+                                                <div>
+                                                        <div class="image fit">
+                                                                <a href="articulo-ai-potenciar-negocio.html" class="gallery-link">
+                                                                        <img src="images/pic04.jpg" alt="" width="600" height="300">
+                                                                        <header class="align-center gallery-title">
+                                                                                <h3>Cómo potenciar tu negocio con AI.</h3>
+                                                                        </header>
+                                                                </a>
+                                                                <p>Conoce estrategias prácticas para implementar soluciones de AI en tu empresa y llevar tus resultados al siguiente nivel.</p>
+                                                        </div>
+                                                </div>
 					</div>
 				</div>
 			</section><!-- Footer --><footer id="footer"><div class="container">


### PR DESCRIPTION
## Summary
- make third entry in "Da un vistazo" section a proper link

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_685c8c3f6dd08322b39bb223fce5884d